### PR TITLE
Prevent GC of client object

### DIFF
--- a/MqttUtilities/Source/MqttUtilities/Private/Mac/MqttRunnable.h
+++ b/MqttUtilities/Source/MqttUtilities/Private/Mac/MqttRunnable.h
@@ -40,6 +40,7 @@ private:
 
 	FCriticalSection* TaskQueueLock;
 
+	UPROPERTY()
 	UMqttClient* client;
 
 public:

--- a/MqttUtilities/Source/MqttUtilities/Private/Windows/MqttRunnable.h
+++ b/MqttUtilities/Source/MqttUtilities/Private/Windows/MqttRunnable.h
@@ -40,6 +40,7 @@ private:
 
 	FCriticalSection* TaskQueueLock;
 
+	UPROPERTY()
 	UMqttClient* client;
 
 public:


### PR DESCRIPTION
We ran into a problem where FMqttRunnable::OnDisconnect crashes when accessing the client object, possibly because it was garbage collected earlier. Noticed that it was not marked with a UPROPERTY() macro.
